### PR TITLE
mapを使用

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -1,22 +1,18 @@
 export const Breadcrumb = () => {
+    const items = ["Home","Library","Date"]
     return (
         <>
             <p>パンくずリスト</p>
             <nav aria-label="breadcrumb">
-            <ol className="breadcrumb">
-                <li className="breadcrumb-item">
-                <a href="#">Home</a>
-                </li>
-                
-                <li className="breadcrumb-item">
-                <a href="#">Library</a>
-                </li>
-                <li className="breadcrumb-item">
-                <a href="#">Date</a>
-                </li>
-            </ol>
+                <ol className="breadcrumb">
+                    {items.map((item) =>(
+                        <li key={item} className="breadcrumb-items">
+                            <a href = "#">{item}</a>
+                        </li>
+                    ))}
+                </ol>
             </nav>
-            </>
+        </>
     );
 };
 


### PR DESCRIPTION
BreadCrumb.tsxをみると、同じような要素が並んでおり、違う部分としてはaタグの中身のみなので
mapを使用

<img width="503" alt="スクリーンショット 2024-06-21 18 42 17" src="https://github.com/Hashimoto-Noriaki/react-practice/assets/73786052/34781fbb-d459-4a71-a503-fc90f803b075">
