### PR TITLE
特定の条件による分岐

### DIFF
--- a/src/components/Breadcrumb.tsx
+++ b/src/components/Breadcrumb.tsx
@@ -3,6 +3,11 @@ export const Breadcrumb = () => {
     return (
         <>
             <p>パンくずリスト</p>
+            {items.length === 0 ?(
+                <p>itemsがありません</p>
+            ): (
+                <p>itemが{items.length}あります</p>
+            )}
             <nav aria-label="breadcrumb">
                 <ol className="breadcrumb">
                     {items.map((item) =>(


### PR DESCRIPTION
itemが3つなので,それが表示されるように修正

<img width="545" alt="スクリーンショット 2024-06-21 18 49 44" src="https://github.com/Hashimoto-Noriaki/react-practice/assets/73786052/30cb3463-418c-4ece-bf67-05963b44ecb3">
