### PR TITLE
アイコンをクリックしたらハートが薄くなる

### DIFF
--- a/src/components/Like.tsx
+++ b/src/components/Like.tsx
@@ -1,5 +1,8 @@
-import { FcLike } from "react-icons/fc";
+import { useState } from "react";
+import { FcLike, FcLikePlaceholder } from "react-icons/fc";
 
 export const Like = () => {
-    return  <FcLike />;
+    const [isLiked, setIsLiked] = useState(false);
+    if (isLiked) return <FcLike onClick={()=> setIsLiked(false)}/>
+    return  <FcLikePlaceholder onClick={()=> setIsLiked(true)}/>;
 };


### PR DESCRIPTION
isLikedがfalseの場合は、FcLikePlaceholderというアイコンを表示し、そのアイコンをクリックした際にはisLikedをtrueとする。

<img width="331" alt="スクリーンショット 2024-06-21 23 35 57" src="https://github.com/Hashimoto-Noriaki/react-practice/assets/73786052/a0011acf-d993-4114-a36d-18e5e5fe033f">
